### PR TITLE
 Make header sticky on Roblox API reference

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -97,9 +97,9 @@ main {
 	margin-top : 0;
 }
 main > header {
-	position: sticky;
-	top: 0;
-	z-index: 1;
+	position : sticky;
+	top      : 0;
+	z-index  : 1;
 }
 main > header > h2 {
 	width : 100%;

--- a/resources/main.css
+++ b/resources/main.css
@@ -98,8 +98,8 @@ main {
 }
 main > header {
 	position: sticky;
-    top: 0;
-    z-index: 1;
+	top: 0;
+	z-index: 1;
 }
 main > header > h2 {
 	width : 100%;

--- a/resources/main.css
+++ b/resources/main.css
@@ -96,6 +96,11 @@ main {
 	margin     : var(--baseline);
 	margin-top : 0;
 }
+main > header {
+	position: sticky;
+    top: 0;
+    z-index: 1;
+}
 main > header > h2 {
 	width : 100%;
 }


### PR DESCRIPTION
Make header sticky on Roblox API reference so that when scrolling on long pages you can still access the search bar.

This is especially bad on long pages such as BasePart.

https://robloxapi.github.io/ref/class/BasePart.html#member-SetNetworkOwnershipAuto

I believe this is an improvement in UX.